### PR TITLE
fix: skip unavailable services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 mgmt-*
 .idea/
+/.crawler_venv/

--- a/crawler.py
+++ b/crawler.py
@@ -123,7 +123,9 @@ class Crawler:
             )
             return None
 
-        if response.status not in [200, 201]:
+        if response.status == 503:
+            self.logger.warning(f"Service '{uri}' is unavailable, skipping.")
+        elif response.status not in [200, 201]:
             self.logger.debug(f"Response.status={response.status}")
             self.logger.debug(f"URI={uri}")
             self.logger.error(f"Failed to communicate with {self.host}")

--- a/crawler.py
+++ b/crawler.py
@@ -124,8 +124,10 @@ class Crawler:
             return None
 
         if response.status == 503:
-            self.logger.warning(f"Service '{uri}' is unavailable, skipping.")
-        elif response.status not in [200, 201]:
+            self.logger.warning(f"Service '{uri}' is unavailable. SKIPPING.")
+            return None
+
+        if response.status not in [200, 201]:
             self.logger.debug(f"Response.status={response.status}")
             self.logger.debug(f"URI={uri}")
             self.logger.error(f"Failed to communicate with {self.host}")


### PR DESCRIPTION
Crawler now warns on unavailable service responses and skips them instead of failing.